### PR TITLE
Changed `get_filters` operator assignments for WS Form integration

### DIFF
--- a/src/Data/WSFormDataSource.php
+++ b/src/Data/WSFormDataSource.php
@@ -175,8 +175,8 @@ final class WSFormDataSource extends BaseDataSource implements MutableDataSource
 			(string) Operator::is()       => '==',
 			(string) Operator::isNot()    => '!=',
 			(string) Operator::isAny()    => 'in',
-			(string) Operator::isAll()    => '==',
-			(string) Operator::isNotAll() => 'in',
+			(string) Operator::isAll()    => 'in',
+			(string) Operator::isNotAll() => 'not_in',
 			(string) Operator::isNone()   => 'not_in'
 		];
 


### PR DESCRIPTION
Changed get_filters operator assignments to best fit with available operators in `WS_Form_Submit_Export` class.