### PR TITLE
Add translation possibilities

### DIFF
--- a/src/Data/CachedDataSource.php
+++ b/src/Data/CachedDataSource.php
@@ -76,7 +76,7 @@ final class CachedDataSource extends BaseDataSource implements MutableDataSource
 			return md5( json_encode( $arguments, JSON_THROW_ON_ERROR ) );
 		} catch ( JsonException $e ) {
 			throw new InvalidArgumentException(
-				'The cache key could not be generated based on the provide arguments',
+				'The cache key could not be generated based on the provided arguments.',
 				$e->getCode(),
 				$e,
 			);

--- a/src/Data/CsvDataSource.php
+++ b/src/Data/CsvDataSource.php
@@ -7,8 +7,8 @@ use CallbackFilterIterator;
 use Closure;
 use DataKit\DataViews\Data\DataMatcher\ArrayDataMatcher;
 use DataKit\DataViews\Data\Exception\DataNotFoundException;
+use DataKit\DataViews\Data\Exception\DataSourceNotFoundException;
 use DataKit\DataViews\DataView\Sort;
-use InvalidArgumentException;
 use Iterator;
 use LimitIterator;
 use SplFileObject;
@@ -34,6 +34,8 @@ final class CsvDataSource extends BaseDataSource {
 	 * @since $ver$
 	 *
 	 * @param string $file_path The file path to the CSV file.
+	 *
+	 * @throws DataSourceNotFoundException When file is not readable.
 	 */
 	public function __construct(
 		string $file_path,
@@ -44,7 +46,7 @@ final class CsvDataSource extends BaseDataSource {
 		if (
 			! file_exists( $file_path )
 			|| ! is_readable( $file_path ) ) {
-			throw new InvalidArgumentException( 'The CSV data source file is not found or readable.' );
+			throw new DataSourceNotFoundException();
 		}
 
 		$this->file = new SplFileObject( $file_path, 'rb' );
@@ -100,7 +102,6 @@ final class CsvDataSource extends BaseDataSource {
 
 		throw DataNotFoundException::with_id( $this, $id );
 	}
-
 
 	/**
 	 * Cleans CSV data.

--- a/src/Data/Exception/ActionForbiddenException.php
+++ b/src/Data/Exception/ActionForbiddenException.php
@@ -37,7 +37,7 @@ final class ActionForbiddenException extends DataSourceException {
 	 */
 	public function __construct(
 		DataSource $data_source,
-		$message = 'Action is forbidden.',
+		$message = 'datakit.action.forbidden',
 		$code = 403,
 		Throwable $previous = null
 	) {
@@ -84,6 +84,6 @@ final class ActionForbiddenException extends DataSourceException {
 			return parent::translate( $translator );
 		}
 
-		return $translator->translate( 'This action is forbidden for data set with id "%s".', $this->id );
+		return $translator->translate( 'datakit.action.forbidden.with_id', [ 'id' => $this->id ] );
 	}
 }

--- a/src/Data/Exception/ActionForbiddenException.php
+++ b/src/Data/Exception/ActionForbiddenException.php
@@ -3,6 +3,7 @@
 namespace DataKit\DataViews\Data\Exception;
 
 use DataKit\DataViews\Data\DataSource;
+use DataKit\DataViews\Translation\Translator;
 use Throwable;
 
 /**
@@ -19,6 +20,15 @@ final class ActionForbiddenException extends DataSourceException {
 	 * @var DataSource
 	 */
 	private DataSource $data_source;
+
+	/**
+	 * The ID of the DataSet.
+	 *
+	 * @since $ve$
+	 *
+	 * @var string
+	 */
+	private string $id;
 
 	/**
 	 * @inheritDoc
@@ -47,7 +57,10 @@ final class ActionForbiddenException extends DataSourceException {
 	 * @return self The exception.
 	 */
 	public static function with_id( DataSource $data_source, string $id ): self {
-		return new self( $data_source, sprintf( 'This action is forbidden for data set with id "%s".', $id ) );
+		$exception     = new self( $data_source );
+		$exception->id = $id;
+
+		return $exception;
 	}
 
 	/**
@@ -59,5 +72,18 @@ final class ActionForbiddenException extends DataSourceException {
 	 */
 	public function data_source(): DataSource {
 		return $this->data_source;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since $ver$
+	 */
+	public function translate( Translator $translator ): string {
+		if ( ! isset( $this->id ) ) {
+			return parent::translate( $translator );
+		}
+
+		return $translator->translate( 'This action is forbidden for data set with id "%s".', $this->id );
 	}
 }

--- a/src/Data/Exception/DataNotFoundException.php
+++ b/src/Data/Exception/DataNotFoundException.php
@@ -3,6 +3,7 @@
 namespace DataKit\DataViews\Data\Exception;
 
 use DataKit\DataViews\Data\DataSource;
+use DataKit\DataViews\Translation\Translator;
 use Throwable;
 
 /**
@@ -19,6 +20,15 @@ final class DataNotFoundException extends DataSourceException {
 	 * @var DataSource
 	 */
 	private DataSource $data_source;
+
+	/**
+	 * The ID of the DataSet.
+	 *
+	 * @since $ve$
+	 *
+	 * @var string
+	 */
+	private string $id;
 
 	/**
 	 * @inheritDoc
@@ -47,7 +57,10 @@ final class DataNotFoundException extends DataSourceException {
 	 * @return self The exception.
 	 */
 	public static function with_id( DataSource $data_source, string $id ): self {
-		return new self( $data_source, sprintf( 'Data set with id "%s" not found.', $id ) );
+		$exception     = new self( $data_source );
+		$exception->id = $id;
+
+		return $exception;
 	}
 
 	/**
@@ -59,5 +72,18 @@ final class DataNotFoundException extends DataSourceException {
 	 */
 	public function data_source(): DataSource {
 		return $this->data_source;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since $ver
+	 */
+	public function translate( Translator $translator ): string {
+		if ( ! isset( $this->id ) ) {
+			return parent::translate( $translator );
+		}
+
+		return $translator->translate( 'Data set with id "%s" not found.', $this->id );
 	}
 }

--- a/src/Data/Exception/DataNotFoundException.php
+++ b/src/Data/Exception/DataNotFoundException.php
@@ -37,7 +37,7 @@ final class DataNotFoundException extends DataSourceException {
 	 */
 	public function __construct(
 		DataSource $data_source,
-		$message = 'Dataset for id not found.',
+		$message = 'datakit.data.not_found',
 		$code = 404,
 		Throwable $previous = null
 	) {
@@ -84,6 +84,6 @@ final class DataNotFoundException extends DataSourceException {
 			return parent::translate( $translator );
 		}
 
-		return $translator->translate( 'Data set with id "%s" not found.', $this->id );
+		return $translator->translate( 'datakit.data.not_found.with_id', [ 'id' => $this->id ] );
 	}
 }

--- a/src/Data/Exception/DataSourceNotFoundException.php
+++ b/src/Data/Exception/DataSourceNotFoundException.php
@@ -17,7 +17,7 @@ final class DataSourceNotFoundException extends DataSourceException {
 	 *
 	 * @phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
 	 */
-	public function __construct( $message = 'Data source not found.', $code = 404, Throwable $previous = null ) {
+	public function __construct( $message = 'datakit.data_source.not_found', $code = 404, Throwable $previous = null ) {
 		parent::__construct( $message, $code, $previous );
 	}
 }

--- a/src/DataView/DataViewNotFoundException.php
+++ b/src/DataView/DataViewNotFoundException.php
@@ -19,7 +19,7 @@ final class DataViewNotFoundException extends DataViewException {
 	 * @param string         $message  The message.
 	 * @param Exception|null $previous The previous exception.
 	 */
-	public function __construct( $message = 'The DataView was not found.', Exception $previous = null ) {
+	public function __construct( $message = 'datakit.dataview.not_found', Exception $previous = null ) {
 		parent::__construct( $message, 404, $previous );
 	}
 }

--- a/src/DataViewException.php
+++ b/src/DataViewException.php
@@ -2,6 +2,8 @@
 
 namespace DataKit\DataViews;
 
+use DataKit\DataViews\Translation\Translatable;
+use DataKit\DataViews\Translation\Translator;
 use Exception;
 
 /**
@@ -9,5 +11,13 @@ use Exception;
  *
  * @since $ver$
  */
-class DataViewException extends Exception {
+class DataViewException extends Exception implements Translatable {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since $ver$
+	 */
+	public function translate( Translator $translator ): string {
+		return $translator->translate( $this->getMessage() );
+	}
 }

--- a/src/Translation/ReplaceParameters.php
+++ b/src/Translation/ReplaceParameters.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DataKit\DataViews\Translation;
+
+/**
+ * Helper trait to replace parameters on a string.
+ *
+ * @since $ver$
+ */
+trait ReplaceParameters {
+	/**
+	 * Replaces any parameters found in square brackets with the value.
+	 *
+	 * @since $ver$
+	 *
+	 * @param string $message    The message.
+	 * @param array  $parameters The parameters to replace.
+	 *
+	 * @return string The message with replaced parameters.
+	 */
+	protected function replace_parameters( string $message, array $parameters = [] ): string {
+		$values = array_values( $parameters );
+		$keys   = array_map( static fn( string $key ): string => '[' . $key . ']', array_keys( $parameters ) );
+
+		return strtr( $message, array_combine( $keys, $values ) );
+	}
+}

--- a/src/Translation/Translatable.php
+++ b/src/Translation/Translatable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DataKit\DataViews\Translation;
+
+/**
+ * Marks a class to be translatable.
+ *
+ * @since $ver$
+ */
+interface Translatable {
+	/**
+	 * Returns a messages through the provided translator.
+	 *
+	 * @since $ver$
+	 *
+	 * @param Translator $translator The translator.
+	 *
+	 * @return string The translation.
+	 */
+	public function translate( Translator $translator ): string;
+}

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DataKit\DataViews\Translation;
+
+/**
+ * Represents a translator that can translate and format a message based on how `sprintf` would work.
+ *
+ * @since $ver$
+ */
+interface Translator {
+	/**
+	 * Translates the message.
+	 *
+	 * @since $ver$
+	 *
+	 * @param string $message   The message to translate.
+	 * @param mixed  ...$values The context needed to complete the translation.
+	 *
+	 * @return string The translated message with the
+	 */
+	public function translate( string $message, ...$values ): string;
+}

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -3,7 +3,7 @@
 namespace DataKit\DataViews\Translation;
 
 /**
- * Represents a translator that can translate and format a message based on how `sprintf` would work.
+ * Represents a translator that can translate a message and replace placeholders.
  *
  * @since $ver$
  */
@@ -13,10 +13,10 @@ interface Translator {
 	 *
 	 * @since $ver$
 	 *
-	 * @param string $message   The message to translate.
-	 * @param mixed  ...$values The context needed to complete the translation.
+	 * @param string $message    The message to translate.
+	 * @param array  $parameters An array of parameters for the message.
 	 *
 	 * @return string The translated message with the
 	 */
-	public function translate( string $message, ...$values ): string;
+	public function translate( string $message, array $parameters = [] ): string;
 }

--- a/tests/Data/CsvDataSourceTest.php
+++ b/tests/Data/CsvDataSourceTest.php
@@ -4,11 +4,11 @@ namespace DataKit\DataViews\Tests\Data;
 
 use DataKit\DataViews\Data\CsvDataSource;
 use DataKit\DataViews\Data\Exception\DataNotFoundException;
+use DataKit\DataViews\Data\Exception\DataSourceNotFoundException;
 use DataKit\DataViews\DataView\Filter;
 use DataKit\DataViews\DataView\Filters;
 use DataKit\DataViews\DataView\Search;
 use DataKit\DataViews\DataView\Sort;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,14 +34,13 @@ final class CsvDataSourceTest extends TestCase {
 		$this->data_source = new CsvDataSource( __DIR__ . '/../assets/oscar-example-data.csv' );
 	}
 
-
 	/**
 	 * Test case for missing or unreadable path.
 	 *
 	 * @since $ver$
 	 */
 	public function test_invalid_path(): void {
-		$this->expectException( InvalidArgumentException::class );
+		$this->expectException( DataSourceNotFoundException::class );
 		new CsvDataSource( 'invalid-path' );
 	}
 

--- a/tests/Data/Exception/ActionForbiddenExceptionTest.php
+++ b/tests/Data/Exception/ActionForbiddenExceptionTest.php
@@ -4,7 +4,7 @@ namespace DataKit\DataViews\Tests\Data\Exception;
 
 use DataKit\DataViews\Data\ArrayDataSource;
 use DataKit\DataViews\Data\Exception\ActionForbiddenException;
-use DataKit\DataViews\Translation\NoopTranslator;
+use DataKit\DataViews\Translation\ReplaceParameters;
 use DataKit\DataViews\Translation\Translator;
 use PHPUnit\Framework\TestCase;
 
@@ -21,8 +21,10 @@ final class ActionForbiddenExceptionTest extends TestCase {
 	 */
 	public function test_exception(): void {
 		$translator = new class implements Translator {
-			public function translate( string $message, ...$values ): string {
-				return sprintf( $message, ...$values );
+			use ReplaceParameters;
+
+			public function translate( string $message, array $parameters = [] ): string {
+				return $this->replace_parameters( $message, $parameters );
 			}
 		};
 
@@ -34,9 +36,6 @@ final class ActionForbiddenExceptionTest extends TestCase {
 		self::assertSame( $data_source, $with_id->data_source() );
 
 		self::assertSame( 'some message', $custom_message->translate( $translator ) );
-		self::assertSame(
-			'This action is forbidden for data set with id "test-id".',
-			$with_id->translate( $translator )
-		);
+		self::assertSame( 'datakit.action.forbidden.with_id', $with_id->translate( $translator ) );
 	}
 }

--- a/tests/Data/Exception/ActionForbiddenExceptionTest.php
+++ b/tests/Data/Exception/ActionForbiddenExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DataKit\DataViews\Tests\Data\Exception;
+
+use DataKit\DataViews\Data\ArrayDataSource;
+use DataKit\DataViews\Data\Exception\ActionForbiddenException;
+use DataKit\DataViews\Translation\NoopTranslator;
+use DataKit\DataViews\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for {@see ActionForbiddenException}
+ *
+ * @since $ver$
+ */
+final class ActionForbiddenExceptionTest extends TestCase {
+	/**
+	 * Test case for {@see ActionForbiddenException}.
+	 *
+	 * @since $ver$
+	 */
+	public function test_exception(): void {
+		$translator = new class implements Translator {
+			public function translate( string $message, ...$values ): string {
+				return sprintf( $message, ...$values );
+			}
+		};
+
+		$data_source    = new ArrayDataSource( 'test', [] );
+		$custom_message = new ActionForbiddenException( $data_source, 'some message' );
+		$with_id        = ActionForbiddenException::with_id( $data_source, 'test-id' );
+
+		self::assertSame( $data_source, $custom_message->data_source() );
+		self::assertSame( $data_source, $with_id->data_source() );
+
+		self::assertSame( 'some message', $custom_message->translate( $translator ) );
+		self::assertSame(
+			'This action is forbidden for data set with id "test-id".',
+			$with_id->translate( $translator )
+		);
+	}
+}

--- a/tests/Data/Exception/DataNotFoundExceptionTest.php
+++ b/tests/Data/Exception/DataNotFoundExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DataKit\DataViews\Tests\Data\Exception;
+
+use DataKit\DataViews\Data\ArrayDataSource;
+use DataKit\DataViews\Data\Exception\DataNotFoundException;
+use DataKit\DataViews\Translation\NoopTranslator;
+use DataKit\DataViews\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for {@see DataNotFoundException}
+ *
+ * @since $ver$
+ */
+final class DataNotFoundExceptionTest extends TestCase {
+	/**
+	 * Test case for {@see DataNotFoundException}.
+	 *
+	 * @since $ver$
+	 */
+	public function test_exception(): void {
+		$translator = new class implements Translator {
+			public function translate( string $message, ...$values ): string {
+				return sprintf( $message, ...$values );
+			}
+		};
+
+		$data_source    = new ArrayDataSource( 'test', [] );
+		$custom_message = new DataNotFoundException( $data_source, 'some message' );
+		$with_id        = DataNotFoundException::with_id( $data_source, 'test-id' );
+
+		self::assertSame( $data_source, $custom_message->data_source() );
+		self::assertSame( $data_source, $with_id->data_source() );
+
+		self::assertSame( 'some message', $custom_message->translate( $translator ) );
+		self::assertSame(
+			'Data set with id "test-id" not found.',
+			$with_id->translate( $translator )
+		);
+	}
+}

--- a/tests/Data/Exception/DataNotFoundExceptionTest.php
+++ b/tests/Data/Exception/DataNotFoundExceptionTest.php
@@ -4,7 +4,7 @@ namespace DataKit\DataViews\Tests\Data\Exception;
 
 use DataKit\DataViews\Data\ArrayDataSource;
 use DataKit\DataViews\Data\Exception\DataNotFoundException;
-use DataKit\DataViews\Translation\NoopTranslator;
+use DataKit\DataViews\Translation\ReplaceParameters;
 use DataKit\DataViews\Translation\Translator;
 use PHPUnit\Framework\TestCase;
 
@@ -21,8 +21,10 @@ final class DataNotFoundExceptionTest extends TestCase {
 	 */
 	public function test_exception(): void {
 		$translator = new class implements Translator {
-			public function translate( string $message, ...$values ): string {
-				return sprintf( $message, ...$values );
+			use ReplaceParameters;
+
+			public function translate( string $message, array $parameters = [] ): string {
+				return $this->replace_parameters( $message, $parameters );
 			}
 		};
 
@@ -34,9 +36,6 @@ final class DataNotFoundExceptionTest extends TestCase {
 		self::assertSame( $data_source, $with_id->data_source() );
 
 		self::assertSame( 'some message', $custom_message->translate( $translator ) );
-		self::assertSame(
-			'Data set with id "test-id" not found.',
-			$with_id->translate( $translator )
-		);
+		self::assertSame( 'datakit.data.not_found.with_id', $with_id->translate( $translator ) );
 	}
 }

--- a/tests/Translation/ReplaceParametersTest.php
+++ b/tests/Translation/ReplaceParametersTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DataKit\DataViews\Tests\Translation;
+
+use DataKit\DataViews\Translation\ReplaceParameters;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for {@see ReplaceParameters}
+ *
+ * @since $ver$
+ */
+final class ReplaceParametersTest extends TestCase {
+	/**
+	 * Test case for
+	 *
+	 * @since $ver$
+	 */
+	public function test_replace_parameters(): void {
+		$replacer = new class {
+			use ReplaceParameters {
+				replace_parameters as public;
+			}
+		};
+
+		self::assertSame(
+			'ID: 123 and name: Person',
+			$replacer->replace_parameters( 'ID: [id] and name: [name]', [ 'id' => '123', 'name' => 'Person' ] )
+		);
+	}
+}


### PR DESCRIPTION
This PR addresses #34.

It adds a `Translator` interface and a `Translatable` interface. Currently I've applied it on 2 exceptions. These exceptions get a `translate(Translator $translator):string` method through the `Translatable` interface. It is then its own responsibility to provide the correct message with the correct context values. 

On the Plugin side we create a `WordPressTranslator` which can be passed to any object that implements the `Translatable` interface.